### PR TITLE
Use ".startswith" instead of ".like" for searching in

### DIFF
--- a/firecli/info.py
+++ b/firecli/info.py
@@ -35,7 +35,7 @@ def punkt(ident: str, **kwargs) -> None:
 
     try:
         punktinfo = (
-            firedb.session.query(pi).filter(pit.name.like("IDENT:%"), pi.tekst == ident).one()
+            firedb.session.query(pi).filter(pit.name.startswith("IDENT:"), pi.tekst == ident).one()
         )
         punkt = punktinfo.punkt
     except NoResultFound:


### PR DESCRIPTION
PunktInformationType. Since we want to exactly match the
beginning of at text string, no reason to do a more fuzzy search.