### PR TITLE
Support multi-point match + points without any obs

### DIFF
--- a/firecli/info.py
+++ b/firecli/info.py
@@ -18,13 +18,13 @@ def info():
     """
     pass
 
-def punkt_rapport(punkt: Punkt) -> None:
+def punkt_rapport(punkt: Punkt, ident: str, i: int, n: int) -> None:
     """
     Rapportgenerator for funktionen 'punkt' nedenfor.
     """
     firecli.print("")
     firecli.print("-"*80)
-    firecli.print(" PUNKT", bold=True)
+    firecli.print(f" PUNKT {ident} ({i}/{n})", bold=True)
     firecli.print("-"*80)
     firecli.print(f"  FIRE ID             :  {punkt.id}")
     firecli.print(f"  Oprettelsesdato     :  {punkt.registreringfra}")
@@ -43,11 +43,11 @@ def punkt_rapport(punkt: Punkt) -> None:
     firecli.print("--- KOORDINATER ---", bold=True)
     punkt.koordinater.sort(key=lambda x: x.srid.name, reverse=False)
     for koord in punkt.koordinater:
-        line = f"    {koord.t.strftime('%Y-%m-%d')}   {koord.srid.name:<15.15} {koord.x}, {koord.y}, {koord.z}"
+        line = f"{koord.t.strftime('%Y-%m-%d')}   {koord.srid.name:<15.15} {koord.x}, {koord.y}, {koord.z}"
         if koord.registreringtil is not None:
-            firecli.print(line, fg="red")
+            firecli.print("     "+line, fg="red")
         else:
-            firecli.print(line, fg="green")
+            firecli.print("   * "+line, fg="green")
     firecli.print("")
 
     firecli.print("--- OBSERVATINONER ---", bold=True)
@@ -91,15 +91,16 @@ def punkt(ident: str, **kwargs) -> None:
         punktinfo = (
             firedb.session.query(pi).filter(pit.name.startswith("IDENT:"), pi.tekst == ident).all()
         )
-        for p in punktinfo:
-            punkt_rapport(p.punkt)
+        n = len(punktinfo)
+        for i in range(n):
+            punkt_rapport(punktinfo[i].punkt, ident, i+1, n)
     except NoResultFound:
         try:
             punkt = firedb.hent_punkt(ident)
         except NoResultFound:
             firecli.print(f"Error! {ident} not found!", fg="red", err=True)
             sys.exit(1)
-        punkt_rapport(punkt)
+        punkt_rapport(punkt, ident, 1, 1)
 
 
 

--- a/firecli/info.py
+++ b/firecli/info.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 import firecli
 from firecli import firedb
-from fireapi.model import PunktInformation, PunktInformationType, Srid
+from fireapi.model import Punkt, PunktInformation, PunktInformationType, Srid
 
 
 @click.group()
@@ -18,7 +18,10 @@ def info():
     """
     pass
 
-def punkt_arbejdshest(punkt, **kwargs) -> None:
+def punkt_rapport(punkt: Punkt) -> None:
+    """
+    Rapportgenerator for funktionen 'punkt' nedenfor.
+    """
     firecli.print("")
     firecli.print("-"*80)
     firecli.print(" PUNKT", bold=True)
@@ -89,14 +92,14 @@ def punkt(ident: str, **kwargs) -> None:
             firedb.session.query(pi).filter(pit.name.startswith("IDENT:"), pi.tekst == ident).all()
         )
         for p in punktinfo:
-            punkt_arbejdshest(p.punkt)
+            punkt_rapport(p.punkt)
     except NoResultFound:
         try:
             punkt = firedb.hent_punkt(ident)
         except NoResultFound:
             firecli.print(f"Error! {ident} not found!", fg="red", err=True)
             sys.exit(1)
-        punkt_arbejdshest(punkt)
+        punkt_rapport(punkt)
 
 
 


### PR DESCRIPTION
"info punkt punkt_id" would crash in cases where multiple
points matched punkt_id, or if the point(s) matched did
not have any observations associated with it.

Since "info punkt punkt_id" matches punkt_id against IDENTs of
all types, we may get more than one match.

For example, the punkt_id 10101 matches both an IDENT:refgeo_id
and an IDENT:diverse for two different IDENT:landsnummer.

This commit refactors and repairs the report generation code,
to loop over all matching points and report on each.

Since it can be hard to see how many points were matched, each
report now features a banner, clearly separating each match.

Points with no observations to/from them also led to a crash.
This has been repaired by skipping all operations accessing
observations, if no observations were found