### PR TITLE
Korriger syntaks for fremfinding af HOME-bibliotek

### DIFF
--- a/firecli/__init__.py
+++ b/firecli/__init__.py
@@ -57,7 +57,7 @@ def print(*args, **kwargs):
 
 # Find settings file and read database credentials
 if os.environ.get("HOME"):
-    home = Path.os.environ["HOME"]
+    home = Path(os.environ["HOME"])
 else:
     home = Path("")
 


### PR DESCRIPTION
Der var en lille syntaksfejl i `__init.py__` som gjorde at alting væltede hvis `HOME` var sat 